### PR TITLE
Revert "src/drivers/net/intel.c: add ID for i219-LM rev 20"

### DIFF
--- a/src/drivers/net/intel.c
+++ b/src/drivers/net/intel.c
@@ -1201,7 +1201,6 @@ static struct pci_device_id intel_nics[] = {
 	PCI_ROM ( 0x8086, 0x1f41, "i354", "I354", INTEL_NO_ASDE ),
 	PCI_ROM ( 0x8086, 0x294c, "82566dc-2", "82566DC-2", 0 ),
 	PCI_ROM ( 0x8086, 0x2e6e, "cemedia", "CE Media Processor", 0 ),
-	PCI_ROM ( 0x8086, 0x550a, "i219lm-20", "I219-LM (20)", INTEL_I219 ),
 };
 
 /** Intel PCI driver */


### PR DESCRIPTION
This reverts commit de0e1cf11bf9f29fde4e6da77f1199091f6b90fa. Turns out that it breaks the i219 when booted over iPXE instead of making it work.